### PR TITLE
acrn: do not fail on non-ACRN systems

### DIFF
--- a/src/acrn/acrn_driver.c
+++ b/src/acrn/acrn_driver.c
@@ -2719,6 +2719,8 @@ acrnStateInitialize(bool privileged,
                     virStateInhibitCallback callback ATTRIBUTE_UNUSED,
                     void *opaque ATTRIBUTE_UNUSED)
 {
+    int ret;
+
     if (!privileged) {
         VIR_INFO("Not running privileged, disabling driver");
         return 0;
@@ -2736,8 +2738,15 @@ acrnStateInitialize(bool privileged,
     if (virCapabilitiesGetNodeInfo(&acrn_driver->nodeInfo) < 0)
         goto cleanup;
 
-    if (acrnInitPlatform(&acrn_driver->pi, &acrn_driver->nodeInfo,
-                         &acrn_driver->vcpuAllocMap) < 0)
+    ret = acrnInitPlatform(&acrn_driver->pi, &acrn_driver->nodeInfo,
+        &acrn_driver->vcpuAllocMap);
+    if (ret == -ENODEV) {
+        /* we are not running on an ACRN enabled system */
+        VIR_INFO("ACRN hypervisor not available, disabling driver");
+        ret = 0;
+        goto cleanup_nofail;
+    }
+    if (ret < 0)
         goto cleanup;
 
     if (!(acrn_driver->domains = virDomainObjListNew()))
@@ -2766,8 +2775,10 @@ acrnStateInitialize(bool privileged,
     return 0;
 
 cleanup:
+    ret = -1;
+cleanup_nofail:
     acrnStateCleanup();
-    return -1;
+    return ret;
 }
 
 static virHypervisorDriver acrnHypervisorDriver = {


### PR DESCRIPTION
To be able to run libvirt on any system we must not fail if there is no
ARCN hypervisor available. Simply skip initialization without failure
in this case.

Signed-off-by: Helmut Buchsbaum <helmut.buchsbaum@opensource.tttech-industrial.com>