### PR TITLE
acrn: cannot start predefined ACRN domain

### DIFF
--- a/src/acrn/acrn_driver.c
+++ b/src/acrn/acrn_driver.c
@@ -2738,11 +2738,42 @@ cleanup:
 }
 
 static int
+acrnPersistentDomainInit(virDomainObjPtr dom, void *opaque)
+{
+    unsigned char hvUUID[VIR_UUID_BUFLEN];
+    char uuidstr[VIR_UUID_STRING_BUFLEN];
+
+    struct acrnVmList *vmList = opaque;
+    acrnDomainObjPrivatePtr priv = dom->privateData;
+    virObjectEventPtr event = NULL;
+
+    if (acrnAllocateVm(acrn_driver->domains, dom->def, &acrn_driver->pi, vmList,
+                       hvUUID) < 0)
+        return -1;
+
+    VIR_DEBUG("Adding ACRN %sdomain %s (%s)",
+              acrnIsRtvm(dom->def) ? "RT " : "",
+              virUUIDFormat(hvUUID, uuidstr), dom->def->name);
+
+    uuid_copy(priv->hvUUID, hvUUID);
+
+    event = virDomainEventLifecycleNewFromObj(dom,
+                                              VIR_DOMAIN_EVENT_DEFINED,
+                                              VIR_DOMAIN_EVENT_DEFINED_ADDED);
+    if (!event)
+        return -1;
+
+    virObjectEventStateQueue(acrn_driver->domainEventState, event);
+    return 0;
+}
+
+static int
 acrnStateInitialize(bool privileged,
                     virStateInhibitCallback callback ATTRIBUTE_UNUSED,
                     void *opaque ATTRIBUTE_UNUSED)
 {
     int ret;
+    struct acrnVmList *list = NULL;
 
     if (!privileged) {
         VIR_INFO("Not running privileged, disabling driver");
@@ -2787,6 +2818,7 @@ acrnStateInitialize(bool privileged,
     if (!(acrn_driver->hostdevMgr = virHostdevManagerGetDefault()))
         goto cleanup;
 
+    /* load inactive persistent configs */
     if (virDomainObjListLoadAllConfigs(acrn_driver->domains,
                                        ACRN_CONFIG_DIR,
                                        ACRN_AUTOSTART_DIR, false,
@@ -2795,12 +2827,25 @@ acrnStateInitialize(bool privileged,
                                        NULL, NULL) < 0)
         goto cleanup;
 
+    list = acrnVmListNew();
+    if (!list)
+        goto cleanup;
+
+    if (acrnGetPlatform(&acrn_driver->pi, list) < 0)
+        goto cleanup;
+
+    if (virDomainObjListForEach(acrn_driver->domains, acrnPersistentDomainInit,
+        list) < 0)
+        goto cleanup;
+
+    acrnVmListFree(list);
     return 0;
 
 cleanup:
     ret = -1;
 cleanup_nofail:
     acrnStateCleanup();
+    acrnVmListFree(list);
     return ret;
 }
 

--- a/src/acrn/acrn_driver.c
+++ b/src/acrn/acrn_driver.c
@@ -323,13 +323,21 @@ acrnFindHvUUID(virDomainObjPtr vm, void *opaque)
     return ret;
 }
 
+static bool
+acrnIsRtvm(virDomainDefPtr def)
+{
+	acrnDomainXmlNsDefPtr nsdef = def->namespaceData;
+
+	return (nsdef && nsdef->rtvm);
+}
+
 /*
  * This function must not be called with any virDomainObjPtr
  * lock held, as it can attempt to hold any such lock in doms.
  */
 static ssize_t
 acrnAllocateVm(virDomainObjListPtr doms, virDomainDefPtr def,
-               acrnPlatformInfoPtr pi, struct acrnVmList *vmList, bool rtvm,
+               acrnPlatformInfoPtr pi, struct acrnVmList *vmList,
                unsigned char *uuid)
 {
     enum acrn_vm_severity severity;
@@ -340,7 +348,7 @@ acrnAllocateVm(virDomainObjListPtr doms, virDomainDefPtr def,
     char *maskstr = NULL;
     char uuidstr[VIR_UUID_STRING_BUFLEN];
 
-    severity = (rtvm) ? SEVERITY_RTVM : SEVERITY_STANDARD_VM;
+    severity = (acrnIsRtvm(def)) ? SEVERITY_RTVM : SEVERITY_STANDARD_VM;
 
     if (def->cpumask) {
         /* prepare a sanitized cpumask */
@@ -583,7 +591,6 @@ acrnProcessPrepareDomain(virDomainObjPtr vm, acrnPlatformInfoPtr pi,
     virDomainDefPtr def;
     virBitmapPtr allowedmask = NULL;
     acrnDomainObjPrivatePtr priv;
-    acrnDomainXmlNsDefPtr nsdef;
     int ret = -1;
 
     if (!vm || !(def = vm->def))
@@ -622,12 +629,10 @@ acrnProcessPrepareDomain(virDomainObjPtr vm, acrnPlatformInfoPtr pi,
         goto cleanup;
     }
 
-    nsdef = def->namespaceData;
-
     /* vCPU placement */
     if (acrnAllocateVcpus(pi,
                           allowedmask ? allowedmask : entry->pcpus,
-                          nsdef && nsdef->rtvm, def->maxvcpus, allocMap,
+                          acrnIsRtvm(def), def->maxvcpus, allocMap,
                           priv->cpuAffinitySet) < 0)
         goto cleanup;
 
@@ -1065,10 +1070,8 @@ acrnBuildStartCmd(virDomainObjPtr vm)
         virCommandAddArg(cmd, virUUIDFormat(priv->hvUUID, uuidstr));
     }
 
-    nsdef = def->namespaceData;
-
     /* RTVM */
-    if (nsdef && nsdef->rtvm)
+    if (acrnIsRtvm(def))
         virCommandAddArgList(cmd,
                              "--lapic_pt",
                              "--virtio_poll", "1000000",
@@ -1085,6 +1088,8 @@ acrnBuildStartCmd(virDomainObjPtr vm)
         virCommandFree(cmd);
         return NULL;
     }
+
+    nsdef = def->namespaceData;
 
     /* User-defined command-line args */
     if (nsdef) {
@@ -1526,7 +1531,6 @@ acrnDomainCreateXML(virConnectPtr conn,
     acrnConnectPtr privconn = conn->privateData;
     struct acrnVmList *vmList = NULL;
     acrnDomainObjPrivatePtr priv;
-    acrnDomainXmlNsDefPtr nsdef;
     virCapsPtr caps = NULL;
     virDomainDefPtr def = NULL;
     virDomainObjPtr vm = NULL;
@@ -1558,11 +1562,9 @@ acrnDomainCreateXML(virConnectPtr conn,
     if (acrnGetPlatform(&privconn->pi, vmList) < 0)
         goto cleanup;
 
-    nsdef = def->namespaceData;
-
     /* get hv UUID for the allocated VM */
     if ((idx = acrnAllocateVm(privconn->domains, def, &privconn->pi, vmList,
-                              nsdef && nsdef->rtvm, hvUUID)) < 0)
+                              hvUUID)) < 0)
         goto cleanup;
 
     if (!(vm = virDomainObjListAdd(privconn->domains, def,
@@ -1703,7 +1705,6 @@ acrnDomainDefineXMLFlags(virConnectPtr conn, const char *xml,
     acrnConnectPtr privconn = conn->privateData;
     struct acrnVmList *vmList = NULL;
     acrnDomainObjPrivatePtr priv;
-    acrnDomainXmlNsDefPtr nsdef;
     virCapsPtr caps = NULL;
     virDomainDefPtr def = NULL, oldDef = NULL;
     virDomainObjPtr vm = NULL;
@@ -1736,11 +1737,9 @@ acrnDomainDefineXMLFlags(virConnectPtr conn, const char *xml,
     if (acrnGetPlatform(&privconn->pi, vmList) < 0)
         goto cleanup;
 
-    nsdef = def->namespaceData;
-
     /* get hv UUID for the allocated VM */
     if (acrnAllocateVm(privconn->domains, def, &privconn->pi, vmList,
-                       nsdef && nsdef->rtvm, hvUUID) < 0)
+                       hvUUID) < 0)
         goto cleanup;
 
     if (!(vm = virDomainObjListAdd(privconn->domains, def,

--- a/src/acrn/acrn_driver.c
+++ b/src/acrn/acrn_driver.c
@@ -2654,20 +2654,12 @@ acrnOfflineCpus(int nprocs, virBitmapPtr pcpus, size_t *allocMap)
 
 static int
 acrnInitPlatform(acrnPlatformInfoPtr pi, virNodeInfoPtr nodeInfo,
-                 size_t **allocMap)
+                 size_t **allocMap, const struct acrnVmList *list)
 {
-    struct acrnVmList *list;
     virBitmapPtr postLaunchedPcpus = NULL;
     uint16_t totalCpus;
     size_t i, *map = NULL;
     int ret;
-
-    if (!(list = acrnVmListNew()))
-        return -ENOMEM;
-
-    ret = acrnGetPlatform(pi, list);
-    if (ret < 0)
-        goto cleanup;
 
     totalCpus = pi->cpu_num;
 
@@ -2733,7 +2725,6 @@ cleanup:
     if (map)
         VIR_FREE(map);
     virBitmapFree(postLaunchedPcpus);
-    acrnVmListFree(list);
     return ret;
 }
 
@@ -2792,8 +2783,11 @@ acrnStateInitialize(bool privileged,
     if (virCapabilitiesGetNodeInfo(&acrn_driver->nodeInfo) < 0)
         goto cleanup;
 
-    ret = acrnInitPlatform(&acrn_driver->pi, &acrn_driver->nodeInfo,
-        &acrn_driver->vcpuAllocMap);
+    list = acrnVmListNew();
+    if (!list)
+        goto cleanup;
+
+    ret = acrnGetPlatform(&acrn_driver->pi, list);
     if (ret == -ENODEV) {
         /* we are not running on an ACRN enabled system */
         VIR_INFO("ACRN hypervisor not available, disabling driver");
@@ -2801,6 +2795,10 @@ acrnStateInitialize(bool privileged,
         goto cleanup_nofail;
     }
     if (ret < 0)
+        goto cleanup;
+
+    if (acrnInitPlatform(&acrn_driver->pi, &acrn_driver->nodeInfo,
+        &acrn_driver->vcpuAllocMap, list) < 0)
         goto cleanup;
 
     if (!(acrn_driver->domains = virDomainObjListNew()))
@@ -2825,13 +2823,6 @@ acrnStateInitialize(bool privileged,
                                        acrn_driver->caps,
                                        acrn_driver->xmlopt,
                                        NULL, NULL) < 0)
-        goto cleanup;
-
-    list = acrnVmListNew();
-    if (!list)
-        goto cleanup;
-
-    if (acrnGetPlatform(&acrn_driver->pi, list) < 0)
         goto cleanup;
 
     if (virDomainObjListForEach(acrn_driver->domains, acrnPersistentDomainInit,


### PR DESCRIPTION
Starting a predefined ACRN VM fails:

```
root@nuc7i7dnh:~# virsh list --all
 Id   Name            State
--------------------------------
 -    DebianBuster0   shut off

root@nuc7i7dnh:~# virsh start DebianBuster0
error: Failed to start domain DebianBuster0
error: internal error: vm(00000000-0000-0000-0000-000000000000) not found

```
The libvirtd log shows

```
libvirtd: 1623: error : acrnDomainCreateWithFlags:1619 : internal error: vm(00000000-0000-0000-0000-000000000000) not found
```
Fix this by populating private data hvUUID for all predefined ACRN domains
in acrnStateInitialize().

Signed-off-by: Helmut Buchsbaum <helmut.buchsbaum@opensource.tttech-industrial.com>