### PR TITLE
schemas: add acrn

### DIFF
--- a/docs/schemas/domaincommon.rng
+++ b/docs/schemas/domaincommon.rng
@@ -209,6 +209,7 @@
         <value>phyp</value>
         <value>vz</value>
         <value>bhyve</value>
+        <value>acrn</value>
       </choice>
     </attribute>
   </define>


### PR DESCRIPTION
Enhance XML schema and add acrn to the known hypervisors. This make 'virsh edit <domain>' work again for ACRN domains.