### PR TITLE
acrn: override virDomainDef->uuid in acrnDomainDefineXMLFlags

### DIFF
--- a/src/acrn/acrn_driver.c
+++ b/src/acrn/acrn_driver.c
@@ -1712,6 +1712,9 @@ acrnDomainDefineXMLFlags(virConnectPtr conn, const char *xml,
                        false, hvUUID) < 0)
         goto cleanup;
 
+    /* update uuid to hvUUID */
+    uuid_copy(def->uuid, hvUUID);
+
     if (!(vm = virDomainObjListAdd(privconn->domains, def,
                                    privconn->xmlopt,
                                    0, &oldDef)))


### PR DESCRIPTION
Since ACRN only can handle specific UUIDs for the domains it supports
(these depend on ACRN scenario configuration used at compile time),
creating a domain with a new random generated UUID does not make any
sense. So, when allocating a VM (with an already known, ACRN supported
UUID), use this very ACRN UUID in the newly generated virDomainDef
object to store the configuration with. This ensures the domain can
later be started from this persistent configuration.

Signed-off-by: Helmut Buchsbaum <helmut.buchsbaum@opensource.tttech-industrial.com>