### PR TITLE
acrn-driver: remove acrn-dm param `-A`

### DIFF
--- a/src/acrn/acrn_driver.c
+++ b/src/acrn/acrn_driver.c
@@ -623,10 +623,6 @@ acrnBuildStartCmd(virDomainObjPtr vm)
 
     priv = vm->privateData;
 
-    /* ACPI */
-    if (def->features[VIR_DOMAIN_FEATURE_ACPI] == VIR_TRISTATE_SWITCH_ON)
-        virCommandAddArg(cmd, "-A");
-
     /* CPU */
     pcpus = virBitmapFormat(priv->cpuAffinitySet);
     virCommandAddArgList(cmd, "--cpu_affinity", pcpus, NULL);


### PR DESCRIPTION
`-A` is used to make acrn-dm generate a ACPI table for a guest VM.
For acrn-dm generate ACPI table automatically now, remove it from
libvirt also.

Signed-off-by: Yuanyuan Zhao <yuanyuan.zhao@linux.intel.com>