### PR TITLE
acrn-driver: add CPU affinity support

### DIFF
--- a/src/acrn/acrn_domain.h
+++ b/src/acrn/acrn_domain.h
@@ -29,6 +29,7 @@ typedef struct _acrnDomainXmlNsDef acrnDomainXmlNsDef;
 typedef acrnDomainXmlNsDef *acrnDomainXmlNsDefPtr;
 struct _acrnDomainXmlNsDef {
     bool rtvm;
+    char *cpu_affinity;
     size_t nargs;
     char **args;
 };


### PR DESCRIPTION
CPU affinity support is added using XML namespace "acrn":

- <acrn:config>: indicate CPU affinity via <acrn:cpu_affinity value='0,2,...'/>
The value of CPU affinity should be target pCPU's local APIC id.

The 'cpuset' attribute of CPU allocation will be invalid but will not
report warning.

Tracked-On: #19
Signed-off-by: Yuanyuan Zhao <yuanyuan.zhao@linux.intel.com>