### PR TITLE
acrn-driver: pass `--rtvm` to acrn-dm instead of `--lapic_pt`

### DIFF
--- a/src/acrn/acrn_driver.c
+++ b/src/acrn/acrn_driver.c
@@ -656,7 +656,7 @@ acrnBuildStartCmd(virDomainObjPtr vm)
     /* RTVM */
     if (acrnIsRtvm(def))
         virCommandAddArgList(cmd,
-                             "--lapic_pt",
+                             "--rtvm",
                              "--virtio_poll", "1000000",
                              NULL);
 


### PR DESCRIPTION
For acrn-dm enable `lapic_pt` automatically for rtvm for better
performance and  reserve `--lapic_pt` for future use,
translate `<acrn:rtvm/>` to `--rtvm` instead of `--lapic_pt`.

Signed-off-by: Yuanyuan Zhao <yuanyuan.zhao@linux.intel.com>