### PR TITLE
acrn_domain : add cpu_affinity to check list

### DIFF
--- a/src/acrn/acrn_domain.c
+++ b/src/acrn/acrn_domain.c
@@ -445,7 +445,7 @@ acrnDomainDefNamespaceParse(xmlXPathContextPtr ctxt,
         acrnDomainDefNamespaceParseCommandlineArgs(nsdata, ctxt) < 0)
         goto cleanup;
 
-    if (nsdata->rtvm || nsdata->nargs)
+    if (nsdata->rtvm || nsdata->nargs || nsdata->cpu_affinity)
         *data = g_steal_pointer(&nsdata);
 
     ret = 0;


### PR DESCRIPTION
Add cpu_affinity to check list when parse acrn name space.

Tracked-On: #19
Signed-off-by: Yuanyuan Zhao <yuanyuan.zhao@linux.intel.com>