### PR TITLE
acrn-driver: ethernet parameter modify

### DIFF
--- a/src/acrn/acrn_driver.c
+++ b/src/acrn/acrn_driver.c
@@ -599,7 +599,7 @@ acrnCommandAddDeviceArg(virDomainDefPtr def,
                 return -1;
 
         virCommandAddArg(cmd, "-s");
-        virCommandAddArgFormat(cmd, "%u:%u:%u,virtio-net,%s,mac=%s",
+        virCommandAddArgFormat(cmd, "%u:%u:%u,virtio-net,tap=%s,mac=%s",
                                info->addr.pci.bus,
                                info->addr.pci.slot,
                                info->addr.pci.function,


### PR DESCRIPTION
Modify ethernet parameter to keep consistent with acrn-dm.

Tracked-On: #24
Signed-off-by: Yuanyuan Zhao <yuanyuan.zhao@linux.intel.com>